### PR TITLE
Typo in constants.py

### DIFF
--- a/blueflower/constants.py
+++ b/blueflower/constants.py
@@ -45,7 +45,7 @@ INFILENAME = (
     '\.kwallet',        # kwallet
     '\.ovpn',           # OpenVPN config
     '\.psafe3',         # passwordsafe
-    '\.pfx'.            # PRX-format keys
+    '\.pfx',            # PRX-format keys
     'cert8.db',         # mozilla
     'connect.inc',      # sql
     'default\.pass',    # dbman


### PR DESCRIPTION
I was looking at some tools including yours (very nice btw), found a typo in a recent commit.