### PR TITLE
better filename matching

### DIFF
--- a/blueflower/core.py
+++ b/blueflower/core.py
@@ -130,7 +130,7 @@ def init(path):
 def scan(path, count):
     """selects files to process, checks file names"""
     log_comment('scanning files...')
-    infilename = re.compile('|'.join(INFILENAME))
+    infilename = re.compile('$|'.join(INFILENAME))
 
     scanned = 0
 

--- a/blueflower/modules/tar.py
+++ b/blueflower/modules/tar.py
@@ -29,7 +29,7 @@ from blueflower.utils.log import log_encrypted, log_error, log_secret
 
 def tar_do_tar(atar, afile):
     """ atar:TarFile, afile:source archive(s) name """
-    infilename = re.compile('|'.join(INFILENAME))
+    infilename = re.compile('$|'.join(INFILENAME))
 
     # iterate over TarInfo's
     for member in atar.getmembers():

--- a/blueflower/modules/zip.py
+++ b/blueflower/modules/zip.py
@@ -39,7 +39,7 @@ def zip_do_zip(azip, afile):
         else:
             log_error(str(e), afile)
 
-    infilename = re.compile('|'.join(INFILENAME))
+    infilename = re.compile('$|'.join(INFILENAME))
 
     # iterate directly over file names
     for member in azip.namelist():


### PR DESCRIPTION
This is a small hack to reduce false positive in file matches. Without it any filename with, for example, "private" as a substring is flagged. I ran the original tool on a codebase that had things like .logo files and "SomePrivateFunction.java" - the result was not too pretty!